### PR TITLE
tests: Create Unit Tests for the Project

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,5 @@ jobs:
       run: dotnet restore cell-cms.sln
     - name: Build
       run: dotnet build --configuration Release --no-restore  cell-cms.sln
-    # Descomentar após criarmos testes pro projeto
-    #- name: Test
-    #  run: dotnet test --no-restore --verbosity normal  cell-cms.sln
+    - name: Test
+      run: dotnet test --no-restore cell-cms.sln

--- a/cell-cms.sln
+++ b/cell-cms.sln
@@ -19,6 +19,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{B50D21C9-B1EA-4537-B5FA-11D3C73D6822}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{8CF2F6D9-10C5-4540-A9AB-BC7E29F75B29}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CellCms.Tests.Unit", "tests\CellCms.Tests.Unit\CellCms.Tests.Unit.csproj", "{BC4AB192-74D0-4EC4-925A-8CA5C0F197F9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,9 +37,16 @@ Global
 		{B50D21C9-B1EA-4537-B5FA-11D3C73D6822}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B50D21C9-B1EA-4537-B5FA-11D3C73D6822}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B50D21C9-B1EA-4537-B5FA-11D3C73D6822}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC4AB192-74D0-4EC4-925A-8CA5C0F197F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC4AB192-74D0-4EC4-925A-8CA5C0F197F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC4AB192-74D0-4EC4-925A-8CA5C0F197F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC4AB192-74D0-4EC4-925A-8CA5C0F197F9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{BC4AB192-74D0-4EC4-925A-8CA5C0F197F9} = {8CF2F6D9-10C5-4540-A9AB-BC7E29F75B29}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73978819-853E-4FDE-A6F6-7C4A900A6471}

--- a/src/CellCms.Api/CellCms.Api.csproj
+++ b/src/CellCms.Api/CellCms.Api.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="CellCms.Tests.Unit" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="logs\**" />
     <Content Remove="logs\**" />
     <EmbeddedResource Remove="logs\**" />

--- a/src/CellCms.Api/Features/Contents/ContentProfile.cs
+++ b/src/CellCms.Api/Features/Contents/ContentProfile.cs
@@ -14,9 +14,17 @@ namespace CellCms.Api.Features.Contents
         public ContentProfile()
         {
             CreateMap<CreateContent, Content>()
-                .ForMember(d => d.ContentTags, opt => opt.MapFrom(s => s.TagsId.Select(t => new ContentTag { TagId = t })));
+                .ForMember(d => d.ContentTags, opt => opt.MapFrom(s => s.TagsId.Select(t => new ContentTag { TagId = t })))
+                .ForMember(d => d.Corpo, opt => opt.MapFrom(s => s.Corpo))
+                .ForMember(d => d.FeedId, opt => opt.MapFrom(s => s.FeedId))
+                .ForMember(d => d.Titulo, opt => opt.MapFrom(s => s.Titulo))
+                .ForAllOtherMembers(opt => opt.Ignore());
             CreateMap<UpdateContent, Content>()
-                .ForMember(d => d.ContentTags, opt => opt.MapFrom(s => s.TagsId.Select(t => new ContentTag { TagId = t })));
+                .ForMember(d => d.Id, opt => opt.MapFrom(s => s.Id))
+                .ForMember(d => d.ContentTags, opt => opt.MapFrom(s => s.TagsId.Select(t => new ContentTag { TagId = t })))
+                .ForMember(d => d.Corpo, opt => opt.MapFrom(s => s.Corpo))
+                .ForMember(d => d.Titulo, opt => opt.MapFrom(s => s.Titulo))
+                .ForAllOtherMembers(opt => opt.Ignore());
             CreateMap<Content, Content>()
                 .ForMember(d => d.Feed, opt => opt.Ignore())
                 .ForMember(d => d.FeedId, opt => opt.Ignore());

--- a/src/CellCms.Api/Features/Contents/ContentsController.cs
+++ b/src/CellCms.Api/Features/Contents/ContentsController.cs
@@ -97,7 +97,7 @@ namespace CellCms.Api.Features.Contents
 
             try
             {
-                var result = await _mediator.Send(command);
+                _ = await _mediator.Send(command);
                 return NoContent();
             }
             catch (KeyNotFoundException)

--- a/src/CellCms.Api/Features/Contents/CreateContent.cs
+++ b/src/CellCms.Api/Features/Contents/CreateContent.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -67,14 +66,6 @@ namespace CellCms.Api.Features.Contents
             {
                 throw new ArgumentNullException(nameof(request));
             }
-
-            //var model = new Content
-            //{
-            //    FeedId = request.FeedId,
-            //    Titulo = request.Titulo,
-            //    Corpo = request.Corpo,
-            //    ContentTags = request.ContentTags.Select(c => new ContentTag { TagId = c.TagId }).ToHashSet()
-            //};
 
             var model = _mapper.Map<Content>(request);
 

--- a/src/CellCms.Api/Features/Feeds/CreateFeed.cs
+++ b/src/CellCms.Api/Features/Feeds/CreateFeed.cs
@@ -55,7 +55,6 @@ namespace CellCms.Api.Features.Feeds
                 throw new ArgumentNullException(nameof(request));
             }
 
-            // TODO: Futuramente mapear de maneira automatica
             var feed = _mapper.Map<Feed>(request);
 
             // Separamos os métodos para que o compilador possa otimizar.

--- a/src/CellCms.Api/Features/Feeds/DeleteFeed.cs
+++ b/src/CellCms.Api/Features/Feeds/DeleteFeed.cs
@@ -3,8 +3,12 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using CellCms.Api.Models;
+
 using MediatR;
+
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace CellCms.Api.Features.Feeds
 {
@@ -43,7 +47,9 @@ namespace CellCms.Api.Features.Feeds
         {
             var existingFeed = await _context
                 .Feeds
-                .FindAsync(new object[] { id }, cancellationToken);
+                .WithId(id)
+                .SingleOrDefaultAsync(cancellationToken);
+
             if (existingFeed is null)
             {
                 throw new KeyNotFoundException($"Não foi encontrado um feed com id {id}");

--- a/src/CellCms.Api/Features/Feeds/FeedProfile.cs
+++ b/src/CellCms.Api/Features/Feeds/FeedProfile.cs
@@ -14,9 +14,14 @@ namespace CellCms.Api.Features.Feeds
         public FeedProfile()
         {
             // Aqui indicamos para o AutoMapper criar, por inferência, o mapeamento entre o CreateFeed e o Feed
-            CreateMap<CreateFeed, Feed>();
+            CreateMap<CreateFeed, Feed>()
+                .ForMember(d => d.Nome, opt => opt.MapFrom(s => s.Nome))
+                .ForAllOtherMembers(opt => opt.Ignore());
             // Aqui indicamos para o AutoMapper criar, por inferência, o mapeamento entre o UpdateFeed e o Feed
-            CreateMap<UpdateFeed, Feed>();
+            CreateMap<UpdateFeed, Feed>()
+                .ForMember(d => d.Id, opt => opt.MapFrom(s => s.Id))
+                .ForMember(d => d.Nome, opt => opt.MapFrom(s => s.Nome))
+                .ForAllOtherMembers(opt => opt.Ignore());
             // Aqui indicamos que o AutoMapepr poderá mapear entre dois objetos do mesmo tipo
             // Porém dizemos que algumas propriedades devem ser ignoradas!
             // Isso é muito importante para não acabarmos atualizando campos que não queremos! Por exemplo relacionamentos!

--- a/src/CellCms.Api/Features/Feeds/ListAllFeeds.cs
+++ b/src/CellCms.Api/Features/Feeds/ListAllFeeds.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
+
+using CellCms.Api.Models;
+
 using MediatR;
 
 using Microsoft.EntityFrameworkCore;
@@ -64,6 +67,7 @@ namespace CellCms.Api.Features.Feeds
         {
             var result = await _context
                 .Feeds
+                .AllFeeds()
                 .AsNoTracking() // Indicando para o EF Core que vamos fazer apenas operações de leitura
                 .Include(f => f.Contents)
                 .Include(f => f.Tags)

--- a/src/CellCms.Api/Features/Feeds/UpdateFeed.cs
+++ b/src/CellCms.Api/Features/Feeds/UpdateFeed.cs
@@ -8,6 +8,8 @@ using FluentValidation;
 
 using MediatR;
 
+using Microsoft.EntityFrameworkCore;
+
 namespace CellCms.Api.Features.Feeds
 {
     /// <summary>
@@ -66,7 +68,8 @@ namespace CellCms.Api.Features.Feeds
         {
             var existingFeed = await _context
                 .Feeds
-                .FindAsync(new object[] { updated.Id }, cancellationToken);
+                .WithId(updated.Id)
+                .SingleOrDefaultAsync(cancellationToken);
 
             if (existingFeed is null)
             {

--- a/src/CellCms.Api/Features/Tags/TagProfile.cs
+++ b/src/CellCms.Api/Features/Tags/TagProfile.cs
@@ -11,8 +11,14 @@ namespace CellCms.Api.Features.Tags
     {
         public TagProfile()
         {
-            CreateMap<CreateTag, Tag>();
-            CreateMap<UpdateTag, Tag>();
+            CreateMap<CreateTag, Tag>()
+                .ForMember(d => d.FeedId, opt => opt.MapFrom(o => o.FeedId))
+                .ForMember(d => d.Nome, opt => opt.MapFrom(o => o.Nome))
+                .ForAllOtherMembers(opt => opt.Ignore());
+            CreateMap<UpdateTag, Tag>()
+                .ForMember(d => d.Id, opt => opt.MapFrom(s => s.Id))
+                .ForMember(d => d.Nome, opt => opt.MapFrom(s => s.Nome))
+                .ForAllOtherMembers(opt => opt.Ignore());
             CreateMap<Tag, Tag>()
                 .ForMember(s => s.ContentTags, opt => opt.Ignore())
                 .ForMember(s => s.Feed, opt => opt.Ignore())

--- a/src/CellCms.Api/Models/Feed.cs
+++ b/src/CellCms.Api/Models/Feed.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace CellCms.Api.Models
 {
@@ -26,5 +27,47 @@ namespace CellCms.Api.Models
         /// Conteúdos do Feed.
         /// </summary>
         public ICollection<Content> Contents { get; set; } = new HashSet<Content>();
+    }
+
+    /// <summary>
+    /// Queries relacionadas a Feeds.
+    /// </summary>
+    public static class FeedQueries
+    {
+        /// <summary>
+        /// Obtem todos os feeds.
+        /// </summary>
+        /// <param name="feeds"></param>
+        /// <returns></returns>
+        public static IQueryable<Feed> AllFeeds(this IQueryable<Feed> feeds) => feeds;
+
+        /// <summary>
+        /// Filtra feeds com base no ID.
+        /// </summary>
+        /// <param name="feeds"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public static IQueryable<Feed> WithId(this IQueryable<Feed> feeds, int id)
+        {
+            return feeds
+                .Where(f => f.Id.Equals(id));
+        }
+
+        /// <summary>
+        /// Filtra feeds com base no Nome.
+        /// </summary>
+        /// <param name="feeds"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static IQueryable<Feed> FilterByNome(this IQueryable<Feed> feeds, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return feeds;
+            }
+
+            return feeds
+                .Where(f => f.Nome.Contains(name, System.StringComparison.InvariantCultureIgnoreCase));
+        }
     }
 }

--- a/tests/CellCms.Tests.Unit/CellCms.Tests.Unit.csproj
+++ b/tests/CellCms.Tests.Unit/CellCms.Tests.Unit.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.15.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.15.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CellCms.Api\CellCms.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CellCms.Tests.Unit/Features/AutoMapperProfileTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/AutoMapperProfileTests.cs
@@ -1,0 +1,21 @@
+﻿
+using AutoMapper;
+
+using CellCms.Tests.Unit.Utils;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features
+{
+    [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+    [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Plumbing)]
+    public class AutoMapperProfileTests
+    {
+        [Theory]
+        [CreateData]
+        public void IMapper_AllProfiles_ValidConfiguration(MapperConfiguration subject)
+        {
+            subject.AssertConfigurationIsValid();
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Contents/ContentsControllerTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Contents/ContentsControllerTests.cs
@@ -1,0 +1,215 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api.Features.Contents;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Contents
+{
+    [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+    [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Plumbing)]
+    public class ContentsControllerTests
+    {
+        private const string _errorMessage = "an error";
+
+        [Theory, CreateData]
+        public async Task Create_InvalidState_ReturnsBadRequest(
+            CreateContent command,
+            [Greedy] ContentsController subject)
+        {
+            // Arrange
+            subject.ModelState
+                .AddModelError(nameof(command.Corpo), _errorMessage);
+
+            // Act
+            var result = await subject.Create(command);
+
+            // Assert
+            result.Should()
+                .NotBeNull().And
+                .BeOfType<BadRequestObjectResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Create_Valid_ReturnsCreated(
+            CreateContent command,
+            Content commandResult,
+            [Frozen] IMediator mediator,
+            [Greedy] ContentsController subject
+            )
+        {
+            // Arrange
+            mediator
+                .Send(command)
+                .Returns(commandResult);
+
+            // Act
+            var result = await subject.Create(command);
+
+            // Assert
+            result.Should()
+                .BeOfType<CreatedResult>().Which
+                .Value.Should().BeEquivalentTo(commandResult);
+        }
+
+        [Theory, CreateData]
+        public async Task Create_NotFound_ReturnsNotFound(
+            CreateContent command,
+            KeyNotFoundException ex,
+            [Frozen] IMediator mediator,
+            [Greedy] ContentsController subject)
+        {
+            // Arrange
+            mediator
+                .Send(command)
+                .Throws(ex);
+
+            // Act
+            var result = await subject.Create(command);
+
+            // Assert
+            result.Should()
+                .BeOfType<NotFoundResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task List_Valid_ReturnsOkObject(
+            ListContent query,
+            IEnumerable<Content> queryResult,
+            [Frozen] IMediator mediator,
+            [Greedy] ContentsController subject)
+        {
+            // Arrange
+            mediator
+                .Send(query)
+                .Returns(queryResult);
+
+            // Act
+            var result = await subject.List(query);
+
+            // Assert
+            result.Should()
+                .BeOfType<OkObjectResult>().Which
+                .Value.Should().BeEquivalentTo(queryResult);
+        }
+
+        [Theory, CreateData]
+        public async Task List_NotFound_ReturnsNotFound(
+            ListContent query,
+            KeyNotFoundException ex,
+            [Frozen] IMediator mediator,
+            [Greedy] ContentsController subject)
+        {
+            // Arrange
+            mediator
+                .Send(query)
+                .Throws(ex);
+
+            // Act
+            var result = await subject.List(query);
+
+            // Assert
+            result.Should()
+                .BeOfType<NotFoundResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Delete_Valid_ReturnsNoContent(
+            DeleteContent command,
+            [Greedy] ContentsController subject)
+        {
+            // Arrange
+
+            // Act
+            var result = await subject.Delete(command);
+
+            // Assert
+            result.Should()
+                .BeOfType<NoContentResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Delete_NotFound_ReturnsNotFound(
+            DeleteContent command,
+            KeyNotFoundException ex,
+            [Frozen] IMediator mediator,
+            [Greedy] ContentsController subject)
+        {
+            // Arrange
+            mediator
+                .Send(command)
+                .Throws(ex);
+
+            // Act
+            var result = await subject.Delete(command);
+
+            // Assert
+            result.Should()
+                .BeOfType<NotFoundResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Update_InvalidState_ReturnsBadRequest(
+            UpdateContent command,
+            [Greedy] ContentsController subject
+            )
+        {
+            // Arrange
+            subject.ModelState
+                .AddModelError(nameof(command.Titulo), _errorMessage);
+
+            // Act
+            var result = await subject.Update(command);
+
+            // Assert
+            result.Should().BeOfType<BadRequestObjectResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Update_Valid_ReturnsNoContent(
+            UpdateContent command,
+            [Greedy] ContentsController subject)
+        {
+            // Arrange
+
+            // Act
+            var result = await subject.Update(command);
+
+            // Assert
+            result.Should().BeOfType<NoContentResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Update_NotFound_ReturnsNotFound(
+            UpdateContent command,
+            KeyNotFoundException ex,
+            [Frozen] IMediator mediator,
+            [Greedy] ContentsController subject)
+        {
+            // Arrange
+            mediator
+                .Send(command)
+                .Throws(ex);
+
+            // Act
+            var result = await subject.Update(command);
+
+            // Assert
+            result.Should().BeOfType<NotFoundResult>();
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Contents/CreateContentTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Contents/CreateContentTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Contents;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using FluentValidation.TestHelper;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Contents
+{
+    public class CreateContentTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+        public class CreateContentValidatorTests
+        {
+            [Theory, CreateData]
+            public void Validate_FeedIdLessThanZero_Throws(CreateContent command,
+                CreateContentValidator subject)
+            {
+                // Arrange
+                command.FeedId = -1;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.FeedId);
+            }
+
+            [Theory, CreateData]
+            public void Validate_TituloEmpty_Throws(CreateContent command,
+                CreateContentValidator subject)
+            {
+                // Arrange
+                command.Titulo = string.Empty;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Titulo);
+            }
+
+            [Theory, CreateData]
+            public void Validate_CorpoEmpty_Throws(CreateContent command,
+                CreateContentValidator subject)
+            {
+                // Arrange
+                command.Corpo = string.Empty;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Corpo);
+            }
+
+            [Theory, CreateData]
+            public void Validate_TagsIdLessThanZero_Throws(CreateContent command,
+                CreateContentValidator subject)
+            {
+                // Arrange
+                command.TagsId = new List<int> { -1 };
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.TagsId);
+            }
+        }
+
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+
+        public class CreateContentHandlerTests
+        {
+            [Theory, CreateData]
+            public async Task Handle_State_ThrowsArgumentNullException(
+                CreateContentHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            public async Task Handle_NotFound_ThrowsKeyNotFoundException(
+                CreateContent command,
+                CreateContentHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(command, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<KeyNotFoundException>();
+            }
+
+            [Theory, CreateData]
+            public async Task Handle_Valid_Returns(
+                CreateContent command,
+                Feed f,
+                [Frozen] CellContext context,
+                CreateContentHandler subject)
+            {
+                // Arrange
+                context.Feeds.Add(f);
+                await context.SaveChangesAsync();
+                command.FeedId = f.Id;
+
+                // Act
+                var result = await subject.Handle(command, default);
+
+                // Assert
+                result.Should()
+                    .NotBeNull().And
+                    .BeEquivalentTo(command, e => e.ExcludingMissingMembers());
+                context.Contents.Should().Contain(result);
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Contents/DeleteContentTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Contents/DeleteContentTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Contents;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Contents
+{
+    public class DeleteContentTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+        public class DeleteContentHandlerTests
+        {
+            [Theory, CreateData]
+            public async Task Handle_NullRequest_ThrowsArgumentNulLException(
+                DeleteContentHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            public async Task Handle_NotFound_ThrowsKeyNotFoundException(
+                DeleteContent command,
+                DeleteContentHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(command, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<KeyNotFoundException>();
+            }
+
+            [Theory, CreateData]
+            public async Task Handle_Valid_Returns(
+                DeleteContent command,
+                Content target,
+                [Frozen] CellContext ctx,
+                DeleteContentHandler subject)
+            {
+                // Arrange
+                ctx.Contents.Add(target);
+                await ctx.SaveChangesAsync();
+                command.Id = target.Id;
+
+                // Act
+                var result = await subject.Handle(command, default);
+
+                // Assert
+                result.Should().NotBeNull();
+                ctx.Contents.Should().NotContain(target);
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Contents/ListContentTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Contents/ListContentTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Contents;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Contents
+{
+    public class ListContentTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+        public class ListContentHandlerTests
+        {
+            [Theory, CreateData]
+            public async Task Handle_NullRequest_ThrowsArgumentNullException(
+                ListContentHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            public async Task Handle_NoFeedNoTag_ReturnsAll(
+                IEnumerable<Content> contents,
+                [Frozen] CellContext ctx,
+                ListContentHandler subject)
+            {
+                // Arrange
+                ctx.Contents.AddRange(contents);
+                await ctx.SaveChangesAsync();
+                var query = new ListContent { };
+
+                // Act
+                var result = await subject.Handle(query, default);
+
+                // Assert
+                result.Should()
+                    .NotBeNull().And
+                    .HaveSameCount(contents);
+            }
+
+            [Theory, CreateData]
+            public async Task Handle_FeedId_ReturnsFilteredByFeed(
+                Feed f,
+                Content c,
+                IEnumerable<Content> contents,
+                [Frozen] CellContext ctx,
+                ListContentHandler subject)
+            {
+                // Arrange
+                f.Contents.Add(c);
+                ctx.Feeds.Add(f);
+                ctx.Contents.AddRange(contents);
+                await ctx.SaveChangesAsync();
+                var query = new ListContent { FeedId = f.Id };
+
+                // Act
+                var result = await subject.Handle(query, default);
+
+                // Assert
+                result.Should()
+                    .NotBeNull().And
+                    .OnlyContain(i => i.FeedId.Equals(f.Id));
+            }
+
+            [Theory, CreateData]
+            public async Task Handle_TagId_ReturnsFilteredByTag(
+                Tag t,
+                Content c,
+                IEnumerable<Content> contents,
+                [Frozen] CellContext ctx,
+                ListContentHandler subject)
+            {
+                // Arrange
+                ctx.Add(t);
+                c.ContentTags.Add(new ContentTag { Content = c, Tag = t });
+                ctx.Add(c);
+                ctx.AddRange(contents);
+                await ctx.SaveChangesAsync();
+                var query = new ListContent { TagId = t.Id };
+
+                // Act
+                var result = await subject.Handle(query, default);
+
+                // Assert
+                result.Should()
+                    .NotBeNull().And
+                    .OnlyContain(c =>
+                        c.ContentTags.All(ct => ct.TagId.Equals(t.Id))
+                    );
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Contents/UpdateContentTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Contents/UpdateContentTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Contents;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using FluentValidation.TestHelper;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Contents
+{
+    public class UpdateContentTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+        public class UpdateContentValidatorTests
+        {
+            [Theory, CreateData]
+            public void Validate_IdLessThanZero_Throws(UpdateContent command,
+                UpdateContentValidator subject)
+            {
+                // Arrange
+                command.Id *= -1;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Id);
+            }
+
+            [Theory, CreateData]
+            public void Validate_TituloEmpty_Throws(UpdateContent command,
+                UpdateContentValidator subject)
+            {
+                // Arrange
+                command.Titulo = string.Empty;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Titulo);
+            }
+
+            [Theory, CreateData]
+            public void Validate_CorpoEmpty_Throws(UpdateContent command,
+                UpdateContentValidator subject)
+            {
+                // Arrange
+                command.Corpo = string.Empty;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Corpo);
+            }
+
+            [Theory, CreateData]
+            public void Validate_TagsLessThanZero_Throws(UpdateContent command,
+                UpdateContentValidator subject)
+            {
+                // Arrange
+                command.TagsId = command.TagsId.Select(t => t * -1);
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.TagsId);
+            }
+        }
+
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+        public class UpdateContentHandlerTests
+        {
+            [Theory, CreateData]
+            public async Task Handle_NullRequest_ThrowsArgumentNullException(
+                UpdateContentHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            public async Task Handle_NotFound_ThrowsKeyNotFoundException(
+                UpdateContent command,
+                UpdateContentHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(command, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<KeyNotFoundException>();
+            }
+
+            [Theory, CreateData]
+            public async Task Handle_Found_Returns(
+                UpdateContent command,
+                Content c,
+                [Frozen] CellContext ctx,
+                UpdateContentHandler subject)
+            {
+                // Arrange
+                command.Id = c.Id;
+                ctx.Add(c);
+                await ctx.SaveChangesAsync();
+
+                // Act
+                var result = await subject.Handle(command, default);
+
+                // Assert
+                result.Should().NotBeNull();
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Feeds/CreateFeedTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Feeds/CreateFeedTests.cs
@@ -1,0 +1,87 @@
+﻿
+using System;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Feeds;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using FluentValidation.TestHelper;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Feeds
+{
+    public class CreateFeedTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class CreateFeedValidatorTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public void Validate_EmptyNome_Throws(CreateFeedValidator subject)
+            {
+                // Arrange
+
+                // Act
+                var result = subject.TestValidate(new CreateFeed { Nome = string.Empty });
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(r => r.Nome);
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public void Validate_Nome_Validates(CreateFeed command, CreateFeedValidator subject)
+            {
+                // Arrange
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldNotHaveAnyValidationErrors();
+            }
+        }
+
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class CreateFeedHandlerTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NullCommand_ThrowsArgumentNullException(CreateFeedHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_ValidRequest_StoresIntoContext(
+                [Frozen] CellContext context,
+                CreateFeed command,
+                CreateFeedHandler subject
+                )
+            {
+                // Arrange
+
+                // Act
+                var result = await subject.Handle(command, default);
+
+                // Assert
+                result.Should().NotBeNull();
+                result.Should().BeEquivalentTo(command);
+                context.Feeds.Should().Contain(result);
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Feeds/DeleteFeedTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Feeds/DeleteFeedTests.cs
@@ -1,0 +1,70 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Feeds;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Feeds
+{
+    public class DeleteFeedTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class DeleteFeedHandlerTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NullRequest_ThrowsArgumentNullException(DeleteFeedHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_FeedNotFound_ThrowsKeyNotFoundException(DeleteFeed request, DeleteFeedHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(request, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<KeyNotFoundException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_FeedExists_ReturnsUnit(
+                [Frozen] CellContext context,
+                Feed feed,
+                DeleteFeedHandler subject)
+            {
+                // Arrange
+                context.Feeds.Add(feed);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = await subject.Handle(new DeleteFeed { Id = feed.Id }, default);
+
+                // Assert
+                result.Should().NotBeNull();
+                context.Feeds.Should().BeEmpty();
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Feeds/FeedControllerTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Feeds/FeedControllerTests.cs
@@ -1,0 +1,174 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api.Features.Feeds;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Feeds
+{
+    [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+    [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Plumbing)]
+    public class FeedControllerTests
+    {
+        [Theory, CreateData]
+        public async Task GetAll_ValidState_ReturnsOkObject(
+            [Frozen] IMediator mediator,
+            IEnumerable<ListFeed> feeds,
+            [Greedy] FeedController subject
+            )
+        {
+            // Arrange
+            mediator
+                .Send(Arg.Any<ListAllFeeds>())
+                .Returns(feeds);
+
+            // Act
+            var result = await subject.GetAll();
+
+            // Assert
+            result.Should()
+                .BeOfType<OkObjectResult>().Which
+                .Value.Should().BeAssignableTo<IEnumerable<ListFeed>>().And
+                .BeEquivalentTo(feeds);
+        }
+
+        [Theory, CreateData]
+        public async Task Delete_ValidPayload_ReturnsNoContent(
+            DeleteFeed payload,
+            [Greedy] FeedController subject
+            )
+        {
+            // Arrange
+
+            // Act
+            var result = await subject.Delete(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<NoContentResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Delete_NotFound_ReturnsNotFound(
+            [Frozen] IMediator mediator,
+            DeleteFeed payload,
+            [Greedy] FeedController subject)
+        {
+            // Arrange
+            mediator
+                .Send(payload)
+                .Throws<KeyNotFoundException>();
+
+            // Act
+            var result = await subject.Delete(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<NotFoundResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Update_ValidPayload_ReturnsNoContent(
+            UpdateFeed payload,
+            [Greedy] FeedController subject)
+        {
+            // Arrange
+
+            // Act
+            var result = await subject.Update(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<NoContentResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Update_NotFound_ReturnsNotFound(
+            [Frozen] IMediator mediator,
+            UpdateFeed payload,
+            [Greedy] FeedController subject)
+        {
+            // Arrange
+            mediator
+                .Send(payload)
+                .Throws<KeyNotFoundException>();
+
+            // Act
+            var result = await subject.Update(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<NotFoundResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Update_BadState_ReturnsBadRequest(
+            UpdateFeed payload,
+            [Greedy] FeedController subject)
+        {
+            // Arrange
+            subject.ModelState
+                .AddModelError(nameof(payload.Nome), "an error");
+
+            // Act
+            var result = await subject.Update(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<BadRequestObjectResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Create_ValidState_ReturnsCreated(
+            [Frozen] IMediator mediator,
+            CreateFeed payload,
+            Feed created,
+            [Greedy] FeedController subject
+            )
+        {
+            // Arrange
+            mediator
+                .Send(payload)
+                .Returns(created);
+
+            // Act
+            var result = await subject.Create(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<CreatedResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Create_BadModelState_ReturnsBadRequest(
+            CreateFeed payload,
+            [Greedy] FeedController subject
+            )
+        {
+            // Arrange
+            subject.ModelState
+                .AddModelError(nameof(payload.Nome), "an error");
+
+            // Act
+            var result = await subject.Create(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<BadRequestObjectResult>();
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Feeds/ListAllFeedsTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Feeds/ListAllFeedsTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Feeds;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Feeds
+{
+    public class ListAllFeedsTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class ListAllFeedsHandlerTests
+        {
+            [Theory]
+            [CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NullRequest_ThrowsArgumentNull(ListAllFeedsHandler subject)
+            {
+                // Arrange            
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act
+                    .Should()
+                    .ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory]
+            [CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_EmptyContext_ReturnsEmptyList(ListAllFeedsHandler subject)
+            {
+                // Arrange
+
+                // Act
+                var result = await subject.Handle(new ListAllFeeds(), default);
+
+                // Assert
+                result
+                    .Should()
+                    .NotBeNull().And
+                    .BeEmpty();
+            }
+
+            [Theory]
+            [CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_ExistingContext_ReturnsList([Frozen] CellContext context,
+                IEnumerable<Feed> feeds,
+                ListAllFeedsHandler subject)
+            {
+                // Arrange
+                context.AddRange(feeds);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = await subject.Handle(new ListAllFeeds(), default);
+
+                // Assert
+                result
+                    .Should()
+                    .NotBeNull().And
+                    .HaveSameCount(context.Feeds);
+            }
+        }
+
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Feeds/UpdateFeedTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Feeds/UpdateFeedTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Feeds;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using FluentValidation.TestHelper;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Feeds
+{
+    public class UpdateFeedTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class UpdateFeedValidatorTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public void Validate_EmptyNome_Throws(UpdateFeedValidator subject)
+            {
+                // Arrange
+
+                // Act
+                var result = subject.TestValidate(new UpdateFeed { Id = 1, Nome = string.Empty });
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Nome);
+            }
+
+            [Theory]
+            [InlineData(-1, "A feed has no name")]
+            [InlineData(-0, "The book is on the table")]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public void Validate_InvalidIds_Throws(int id, string name)
+            {
+                // Arrange
+                var subject = new UpdateFeedValidator();
+
+                // Act
+                var result = subject.TestValidate(new UpdateFeed { Id = id, Nome = name });
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Id);
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public void Validate_ValidCommand_Returns(UpdateFeed command, UpdateFeedValidator subject)
+            {
+                // Arrange
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldNotHaveAnyValidationErrors();
+            }
+        }
+
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class UpdateFeedHandlerTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NullCommand_ThrowsArgumentNullException(
+                UpdateFeedHandler subject
+                )
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_FeedNotFound_ThrowsKeyNotFoundException(
+                UpdateFeed command,
+                UpdateFeedHandler subject
+                )
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(command, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<KeyNotFoundException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_FeedFound_Returns(
+                Feed feed,
+                UpdateFeed command,
+                [Frozen] CellContext context,
+                UpdateFeedHandler subject
+                )
+            {
+                // Arrange
+                context.Feeds.Add(feed);
+                await context.SaveChangesAsync();
+                command.Id = feed.Id;
+
+                // Act
+                var result = await subject.Handle(command, default);
+
+                // Assert
+                result.Should().NotBeNull();
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Tags/CreateTagTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Tags/CreateTagTests.cs
@@ -1,0 +1,112 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Tags;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using FluentValidation.TestHelper;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Tags
+{
+    public class CreateTagTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class CreateTagValidatorTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public void Validate_LowerThanZeroId_Throws(CreateTag command,
+                CreateTagValidator subject)
+            {
+                // Arrange
+                command.FeedId = -1;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.FeedId);
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public void Validate_EmptyName_Throws(CreateTag command,
+                CreateTagValidator subject)
+            {
+                // Arrange
+                command.Nome = string.Empty;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Nome);
+            }
+        }
+
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class CreateTagHandlerTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NullRequest_ThrowsArgumentNullException(
+                CreateTagHandler subject
+                )
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NotFound_ThrowsKeyNotFoundException(
+                CreateTag command,
+                CreateTagHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(command, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<KeyNotFoundException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_Valid_Returns(
+                CreateTag command,
+                Feed f,
+                [Frozen] CellContext context,
+                CreateTagHandler subject)
+            {
+                // Arrange
+                f.Id = command.FeedId;
+                context.Feeds.Add(f);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = subject.Handle(command, default);
+
+                // Assert
+                result.Should().NotBeNull();
+                context.Tags.Should().ContainEquivalentOf(command);
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Tags/DeleteTagTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Tags/DeleteTagTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Tags;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Tags
+{
+    public class DeleteTagTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class DeleteTagHandlerTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NullRequest_ThrowsArgumentNullException(
+                DeleteTagHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NotFound_ThrowsKeyNotFoundException(
+                DeleteTag command,
+                DeleteTagHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(command, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<KeyNotFoundException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_Found_Returns(
+                DeleteTag command,
+                Tag tag,
+                [Frozen] CellContext context,
+                DeleteTagHandler subject)
+            {
+                // Arrange
+                tag.Id = command.Id;
+                context.Tags.Add(tag);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = await subject.Handle(command, default);
+
+                // Assert
+                result.Should().NotBeNull();
+                context
+                    .Tags
+                    .Should().NotContain(tag);
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Tags/ListTagsTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Tags/ListTagsTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Tags;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Tags
+{
+    public class ListTagsTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class ListTagsHandlerTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NullRequest_ThrowsArgumentNullException(
+                ListTagsHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NullFeed_Returns(
+                ListTags request,
+                IEnumerable<Tag> tags,
+                [Frozen] CellContext context,
+                ListTagsHandler subject)
+            {
+                // Arrange
+                request.FeedId = null;
+                context.Tags.AddRange(tags);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = await subject.Handle(request, default);
+
+                // Assert
+                result.Should()
+                    .NotBeNull().And
+                    .HaveSameCount(context.Tags);
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NotNullFeed_Returns(
+                ListTags request,
+                Feed feed,
+                Tag tag,
+                [Frozen] CellContext context,
+                ListTagsHandler subject)
+            {
+                // Arrange
+                request.FeedId = feed.Id;
+                feed.Tags.Add(tag);
+                context.Feeds.Add(feed);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = await subject.Handle(request, default);
+
+                // Assert
+                result.Should()
+                    .NotBeNull().And
+                    .HaveSameCount(feed.Tags);
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Tags/TagsControllerTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Tags/TagsControllerTests.cs
@@ -1,0 +1,211 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api.Features.Tags;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Tags
+{
+    [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+    [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Plumbing)]
+    public class TagsControllerTests
+    {
+        [Theory, CreateData]
+        public async Task Create_ValidPayload_ReturnsCreatedObject(
+            CreateTag payload,
+            Tag payloadResult,
+            [Frozen] IMediator mediator,
+            [Greedy] TagsController subject)
+        {
+            // Arrange
+            mediator
+                .Send(payload)
+                .Returns(payloadResult);
+
+            // Act
+            var result = await subject.Create(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<CreatedResult>().Which
+                .Value.Should().BeEquivalentTo(payloadResult);
+        }
+
+        [Theory, CreateData]
+        public async Task Create_InvalidPayload_ReturnsBadRequest(
+            CreateTag payload,
+            [Greedy] TagsController subject)
+        {
+            // Arrange
+            subject.ModelState
+                .AddModelError(nameof(payload.Nome), "an error");
+
+            // Act
+            var result = await subject.Create(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<BadRequestObjectResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task List_ValidPayload_ReturnsOkObject(
+            ListTags payload,
+            IEnumerable<Tag> payloadResults,
+            [Frozen] IMediator mediator,
+            [Greedy] TagsController subject)
+        {
+            // Arrange
+            mediator
+                .Send(payload)
+                .Returns(payloadResults);
+
+            // Act
+            var result = await subject.List(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<OkObjectResult>().Which
+                .Value.Should().BeEquivalentTo(payloadResults);
+        }
+
+        [Theory, CreateData]
+        public async Task List_NotFound_ReturnsNotFound(
+            ListTags payload,
+            [Frozen] IMediator mediator,
+            [Greedy] TagsController subject)
+        {
+            // Arrange
+            mediator
+                .Send(payload)
+                .Throws<KeyNotFoundException>();
+
+            // Act
+            var result = await subject.List(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<NotFoundResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task List_InvalidPayload_ReturnsBadRequest(
+            ListTags payload,
+            [Greedy] TagsController subject)
+        {
+            // Arrange
+            subject.ModelState
+                .AddModelError(nameof(payload.FeedId), "an error");
+
+            // Act
+            var result = await subject.List(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<BadRequestObjectResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Delete_ValidPayload_ReturnsNoContent(
+            DeleteTag payload,
+            [Greedy] TagsController subject
+            )
+        {
+            // Arrange
+
+            // Act
+            var result = await subject.Delete(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<NoContentResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Delete_NotFound_ReturnsNotFound(
+            DeleteTag payload,
+            [Frozen] IMediator mediator,
+            [Greedy] TagsController subject
+            )
+        {
+            // Arrange
+            mediator
+                .Send(payload)
+                .Throws<KeyNotFoundException>();
+
+            // Act
+            var result = await subject.Delete(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<NotFoundResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Update_InvalidPayload_ReturnsBadRequest(
+            UpdateTag payload,
+            [Greedy] TagsController subject
+            )
+        {
+            // Arrange
+            subject.ModelState
+                .AddModelError(nameof(payload.Nome), "an error");
+
+            // Act
+            var result = await subject.Update(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<BadRequestObjectResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Update_ValidPayload_ReturnsNoContent(
+            UpdateTag payload,
+            [Greedy] TagsController subject
+            )
+        {
+            // Arrange
+
+            // Act
+            var result = await subject.Update(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<NoContentResult>();
+        }
+
+        [Theory, CreateData]
+        public async Task Update_NotFound_ReturnsNotFound(
+            UpdateTag payload,
+            [Frozen] IMediator mediator,
+            [Greedy] TagsController subject)
+        {
+            // Arrange
+            mediator
+                .Send(payload)
+                .Throws<KeyNotFoundException>();
+
+            // Act
+            var result = await subject.Update(payload);
+
+            // Assert
+            result.Should()
+                .BeOfType<NotFoundResult>();
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Features/Tags/UpdateTagTests.cs
+++ b/tests/CellCms.Tests.Unit/Features/Tags/UpdateTagTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api;
+using CellCms.Api.Features.Tags;
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using FluentValidation.TestHelper;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Features.Tags
+{
+    public class UpdateTagTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class UpdateTagValidatorTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public void Validate_IdLessThanZero_Throws(UpdateTag command,
+                UpdateTagValidator subject)
+            {
+                // Arrange
+                command.Id = -1;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Id);
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public void Validate_EmptyName_Throws(UpdateTag command,
+                UpdateTagValidator subject)
+            {
+                // Arrange
+                command.Nome = string.Empty;
+
+                // Act
+                var result = subject.TestValidate(command);
+
+                // Assert
+                result.ShouldHaveValidationErrorFor(c => c.Nome);
+            }
+        }
+
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+
+        public class UpdateTagHandlerTests
+        {
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NullRequest_ThrowsArgumentNullException(
+                UpdateTagHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(null, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<ArgumentNullException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_NotFound_ThrowsKeyNotFoundException(
+                UpdateTag command,
+                UpdateTagHandler subject)
+            {
+                // Arrange
+
+                // Act
+                Func<Task> act = () => subject.Handle(command, default);
+
+                // Assert
+                await act.Should().ThrowExactlyAsync<KeyNotFoundException>();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Feature)]
+            public async Task Handle_Found_Returns(
+                Tag tag,
+                UpdateTag command,
+                [Frozen] CellContext ctx,
+                UpdateTagHandler subject)
+            {
+                // Arrange
+                string nomeOriginal = tag.Nome;
+                ctx.Tags.Add(tag);
+                await ctx.SaveChangesAsync();
+                command.Id = tag.Id;
+
+                // Act
+                var result = await subject.Handle(command, default);
+
+                // Assert
+                result.Should().NotBeNull();
+                ctx.Tags
+                    .SingleOrDefault().Nome
+                    .Should()
+                        .NotBeEquivalentTo(nomeOriginal);
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Models/FeedTests.cs
+++ b/tests/CellCms.Tests.Unit/Models/FeedTests.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using AutoFixture.Xunit2;
+
+using CellCms.Api.Models;
+using CellCms.Tests.Unit.Utils;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace CellCms.Tests.Unit.Models
+{
+    public class FeedTests
+    {
+        [Trait(TraitsConstants.Category.Name, TraitsConstants.Category.Values.Unit)]
+        public class FeedQueriesTests
+        {
+            private readonly IEnumerable<Feed> _emptyResult;
+
+            public FeedQueriesTests()
+            {
+                _emptyResult = Enumerable.Empty<Feed>();
+            }
+
+            [Fact]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Domain)]
+            public void AllFeeds_EmptyData_ReturnsEmpty()
+            {
+                // Arrange
+                var subject = _emptyResult.AsQueryable();
+
+                // Act
+                var result = subject.AllFeeds();
+
+                // Assert
+                result.Should().BeEmpty();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Domain)]
+            public void AllFeeds_WithData_ReturnsData(IEnumerable<Feed> feeds)
+            {
+                // Arrange
+                var subject = feeds.AsQueryable();
+
+                // Act
+                var result = subject.AllFeeds();
+
+                // Assert
+                result.Should()
+                    .NotBeEmpty().And
+                    .HaveSameCount(feeds);
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Domain)]
+            public void ById_EmptyData_ReturnsEmpty(int id)
+            {
+                // Arrange
+                var subject = _emptyResult.AsQueryable();
+
+                // Act
+                var result = subject.WithId(id);
+
+                // Assert
+                result.Should().BeEmpty();
+                result.SingleOrDefault().Should().BeNull();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Domain)]
+            public void ById_WithDataAndValidId_ReturnsData(IEnumerable<Feed> feeds, Feed extraFeed)
+            {
+                // Arrange
+                var id = extraFeed.Id;
+                var subject = feeds
+                    .Concat(new List<Feed>() { extraFeed })
+                    .AsQueryable();
+
+                // Act
+                var result = subject.WithId(id);
+
+                // Assert
+                result.Should().NotBeEmpty();
+                result.SingleOrDefault().Should()
+                    .BeEquivalentTo(extraFeed);
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Domain)]
+            public void ById_WithDataAndInvalidId_ReturnsData(IEnumerable<Feed> feeds, [Frozen] int id)
+            {
+                // Arrange
+                var realId = id + 200;
+                var subject = feeds.AsQueryable();
+
+                // Act
+                var result = subject
+                    .WithId(realId);
+
+                // Assert
+                result.Should().BeEmpty();
+                result.SingleOrDefault().Should().BeNull();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Domain)]
+            public void WithNome_EmptyData_ReturnsEmpty(string nome)
+            {
+                // Arrange
+                var subject = _emptyResult.AsQueryable();
+
+                // Act
+                var result = subject
+                    .FilterByNome(nome);
+
+                // Assert
+                result.Should().BeEmpty();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Domain)]
+            public void WithNome_WithDataAndValidName_ReturnsData(IEnumerable<Feed> feeds, Feed extraFeed)
+            {
+                // Arrange
+                var nome = extraFeed.Nome;
+                var subject = feeds
+                    .Concat(new List<Feed>() { extraFeed })
+                    .AsQueryable();
+
+                // Act
+                var result = subject
+                    .FilterByNome(nome);
+
+                // Assert
+                result.Should().NotBeEmpty();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Domain)]
+            public void WithNome_WithDataAndInvalidName_ReturnsData(IEnumerable<Feed> feeds, [Frozen] string fixedName)
+            {
+                // Arrange
+                var nome = $"{fixedName}{Guid.NewGuid()}";
+                var subject = feeds.AsQueryable();
+
+                // Act
+                var result = subject
+                    .FilterByNome(nome);
+
+                // Assert
+                result.Should().BeEmpty();
+            }
+
+            [Theory, CreateData]
+            [Trait(TraitsConstants.Label.Name, TraitsConstants.Label.Values.Domain)]
+            public void WithIdAndNome_WithDataAndValidNameAndValidID_ReturnsData(IEnumerable<Feed> feeds, Feed extraFeed)
+            {
+                // Arrange
+                var nome = extraFeed.Nome;
+                var id = extraFeed.Id;
+                var subject = feeds
+                    .Concat(new List<Feed>() { extraFeed })
+                    .AsQueryable();
+
+                // Act
+                var result = subject
+                    .WithId(id)
+                    .FilterByNome(nome);
+
+                // Assert
+                result.Should().NotBeEmpty();
+            }
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Utils/CreateDataAttribute.cs
+++ b/tests/CellCms.Tests.Unit/Utils/CreateDataAttribute.cs
@@ -1,0 +1,76 @@
+﻿using System;
+
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.Xunit2;
+
+using AutoMapper;
+
+using CellCms.Api;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace CellCms.Tests.Unit.Utils
+{
+    /// <summary>
+    /// Atributo para configurar automaticamente os dados de um test case.
+    /// </summary>
+    public class CreateDataAttribute : AutoDataAttribute
+    {
+        public CreateDataAttribute() : base(SetupCellCmsFixture)
+        {
+
+        }
+
+        /// <summary>
+        /// Configura uma fixture com todos os objetos necessários para
+        /// testar o CellCMS.
+        /// </summary>
+        /// <returns></returns>
+        private static IFixture SetupCellCmsFixture()
+        {
+            var fix = new Fixture();
+            fix.Customize(new AutoNSubstituteCustomization());
+            SetupRecursionBehaviors(fix);
+            SetupCellContext(fix);
+            SetupAutoMapper(fix);
+            return fix;
+        }
+
+        /// <summary>
+        /// Configura e Injeta uma instância do AutoMapper.
+        /// </summary>
+        /// <param name="fix"></param>
+        private static void SetupAutoMapper(Fixture fix)
+        {
+            var autoMapperConfig = new MapperConfiguration(cfg =>
+            {
+                cfg.AddMaps(typeof(Startup));
+            });
+            fix.Inject(autoMapperConfig);
+            fix.Inject(autoMapperConfig.CreateMapper());
+        }
+
+        /// <summary>
+        /// Configura e Injeta uma instância do CellContext.
+        /// </summary>
+        /// <param name="fix"></param>
+        private static void SetupCellContext(Fixture fix)
+        {
+            var dbOptions = new DbContextOptionsBuilder()
+                            .UseInMemoryDatabase(Guid.NewGuid().ToString());
+            fix.Inject(new CellContext(dbOptions.Options));
+        }
+
+        /// <summary>
+        /// Configura o comportamento da Fixture durante
+        /// chamadas recursivas.
+        /// </summary>
+        /// <param name="fix"></param>
+        private static void SetupRecursionBehaviors(Fixture fix)
+        {
+            fix.Behaviors.Remove(new ThrowingRecursionBehavior());
+            fix.Behaviors.Add(new OmitOnRecursionBehavior());
+        }
+    }
+}

--- a/tests/CellCms.Tests.Unit/Utils/TraitsConstants.cs
+++ b/tests/CellCms.Tests.Unit/Utils/TraitsConstants.cs
@@ -1,0 +1,65 @@
+﻿namespace CellCms.Tests.Unit.Utils
+{
+    /// <summary>
+    /// Constantes para organizar os Traits dos testes.
+    /// </summary>
+    public static class TraitsConstants
+    {
+        /// <summary>
+        /// Categorias para um teste.
+        /// </summary>
+        public static class Category
+        {
+            public const string Name = nameof(Category);
+
+            public class Values
+            {
+                /// <summary>
+                /// Teste Unitário.
+                /// </summary>
+                public const string Unit = nameof(Unit);
+
+                /// <summary>
+                /// Teste de Integração.
+                /// </summary>
+                public const string Integration = nameof(Integration);
+
+                /// <summary>
+                /// Teste de Funcionalidade.
+                /// </summary>
+                public const string Feature = nameof(Feature);
+            }
+        }
+
+        /// <summary>
+        /// Labels para um teste.
+        /// </summary>
+        public static class Label
+        {
+            public const string Name = nameof(Label);
+
+            public class Values
+            {
+                /// <summary>
+                /// Uma funcionalidade do sistema.
+                /// </summary>
+                public const string Feature = nameof(Feature);
+
+                /// <summary>
+                /// Um bug descoberto.
+                /// </summary>
+                public const string Bug = nameof(Bug);
+
+                /// <summary>
+                /// Utilitários, middlewares, configurações, et cetera...
+                /// </summary>
+                public const string Plumbing = nameof(Plumbing);
+
+                /// <summary>
+                /// O domínio em si.
+                /// </summary>
+                public const string Domain = nameof(Domain);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit ensures we're now testing the features and controllers of
the Project.

Squashes:

* tests: Create Unit Test project
* tests: Unit test ListAllFeeds
* tests: Unit test AutoMapper Profiles
* housekeeping: Run tests on CICD pipeline
* tests: Fix AutoMapper's profiles
* housekeeping: Organize tests with Traits
* refactor: Move Feed Queries to the Domain
* tests: Write tests for DeleteFeeds
* tests: Write tests for Chaining queries
* tests: Cover CreateFeed with tests
* housekeeping: Make API internals visible to Unit Tests
* tests: Cover UpdateeFeed with tests
* tests: Cover FeedController with tests
* tests: Cover TagsController
* tests: Cover Features.Tags
* tests: Cover Features.Contents