### PR TITLE
feat: Support Cancellation on API's Endpoints

### DIFF
--- a/src/CellCms.Api/Features/Contents/ContentsController.cs
+++ b/src/CellCms.Api/Features/Contents/ContentsController.cs
@@ -33,12 +33,16 @@ namespace CellCms.Api.Features.Contents
 
             try
             {
-                var result = await _mediator.Send(command);
+                var result = await _mediator.Send(command, this.GetRequestCancellationToken());
                 return Created(string.Empty, result);
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {
@@ -52,12 +56,16 @@ namespace CellCms.Api.Features.Contents
         {
             try
             {
-                var result = await _mediator.Send(query);
+                var result = await _mediator.Send(query, this.GetRequestCancellationToken());
                 return Ok(result);
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {
@@ -72,12 +80,16 @@ namespace CellCms.Api.Features.Contents
         {
             try
             {
-                _ = await _mediator.Send(command);
+                _ = await _mediator.Send(command, this.GetRequestCancellationToken());
                 return NoContent();
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {
@@ -97,12 +109,16 @@ namespace CellCms.Api.Features.Contents
 
             try
             {
-                _ = await _mediator.Send(command);
+                _ = await _mediator.Send(command, this.GetRequestCancellationToken());
                 return NoContent();
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {

--- a/src/CellCms.Api/Features/ControllerBaseExtensions.cs
+++ b/src/CellCms.Api/Features/ControllerBaseExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace CellCms.Api.Features
+{
+    /// <summary>
+    /// Métodos para estender a funcionalidade dos Controllers
+    /// </summary>
+    public static class ControllerBaseExtensions
+    {
+        /// <summary>
+        /// Obtém um CancellationToken de uma Request HTTP OU cria um novo.
+        /// </summary>
+        /// <param name="controller"></param>
+        /// <returns>Um CancellationToken pronto para uso</returns>
+        public static CancellationToken GetRequestCancellationToken(this ControllerBase controller)
+        {
+            return controller?.HttpContext?.RequestAborted ?? default;
+        }
+    }
+}

--- a/src/CellCms.Api/Features/Feeds/CreateFeed.cs
+++ b/src/CellCms.Api/Features/Feeds/CreateFeed.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using AutoMapper;
+
 using CellCms.Api.Models;
 
 using FluentValidation;
@@ -33,7 +35,7 @@ namespace CellCms.Api.Features.Feeds
                 .MaximumLength(200);
         }
     }
-    
+
     /// <summary>
     /// Handler para a criação de feeds.
     /// </summary>
@@ -58,7 +60,7 @@ namespace CellCms.Api.Features.Feeds
             var feed = _mapper.Map<Feed>(request);
 
             // Separamos os métodos para que o compilador possa otimizar.
-            // No método principal realizamos apenas operações sincronas
+            // No método principal realizamos apenas operações síncronas
             // No método interno realizamos as operações assíncronas
             return CreateFeedInternalAsync(feed, cancellationToken);
         }

--- a/src/CellCms.Api/Features/Feeds/FeedController.cs
+++ b/src/CellCms.Api/Features/Feeds/FeedController.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CellCms.Api.Features.Feeds
 {
+
     [Route("api/[controller]")]
     public class FeedController : ControllerBase
     {
@@ -34,17 +35,16 @@ namespace CellCms.Api.Features.Feeds
 
             try
             {
-                var result = await _mediator.Send(command);
+                var result = await _mediator.Send(command, this.GetRequestCancellationToken());
                 return Created(string.Empty, result);
             }
-            catch (ArgumentException ex)
+            catch (TaskCanceledException)
             {
-                // Futuramente será tratado pelo ModelState.
-                return BadRequest(ex.Message);
+                return NoContent();
             }
             catch (Exception ex)
             {
-                // Caso seja algum erro que não esperavamos, vamos fazer um log decente deste erro.
+                // Caso seja algum erro que não esperávamos, vamos fazer um log decente deste erro.
                 _logger.LogError(ex, "Erro ao tentar criar um novo Feed: {@Command}", command);
                 throw;
             }
@@ -56,8 +56,12 @@ namespace CellCms.Api.Features.Feeds
             var query = new ListAllFeeds();
             try
             {
-                var result = await _mediator.Send(query);
+                var result = await _mediator.Send(query, this.GetRequestCancellationToken());
                 return Ok(result);
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {
@@ -78,12 +82,16 @@ namespace CellCms.Api.Features.Feeds
 
             try
             {
-                await _mediator.Send(command);
+                await _mediator.Send(command, this.GetRequestCancellationToken());
                 return NoContent();
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {
@@ -98,12 +106,16 @@ namespace CellCms.Api.Features.Feeds
         {
             try
             {
-                await _mediator.Send(command);
+                await _mediator.Send(command, this.GetRequestCancellationToken());
                 return NoContent();
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {

--- a/src/CellCms.Api/Features/Tags/TagsController.cs
+++ b/src/CellCms.Api/Features/Tags/TagsController.cs
@@ -33,12 +33,16 @@ namespace CellCms.Api.Features.Tags
 
             try
             {
-                var result = await _mediator.Send(command);
+                var result = await _mediator.Send(command, this.GetRequestCancellationToken());
                 return Created(string.Empty, result);
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {
@@ -57,12 +61,16 @@ namespace CellCms.Api.Features.Tags
 
             try
             {
-                var result = await _mediator.Send(query);
+                var result = await _mediator.Send(query, this.GetRequestCancellationToken());
                 return Ok(result);
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {
@@ -77,12 +85,16 @@ namespace CellCms.Api.Features.Tags
         {
             try
             {
-                await _mediator.Send(command);
+                await _mediator.Send(command, this.GetRequestCancellationToken());
                 return NoContent();
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {
@@ -102,12 +114,16 @@ namespace CellCms.Api.Features.Tags
 
             try
             {
-                await _mediator.Send(command);
+                await _mediator.Send(command, this.GetRequestCancellationToken());
                 return NoContent();
             }
             catch (KeyNotFoundException)
             {
                 return NotFound();
+            }
+            catch (TaskCanceledException)
+            {
+                return NoContent();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This commit allows us to properly cancel server work after a user
drops/stops his connection during a HTTP Request.

Squashes:

* feat: Create extensions to support Cancellation
* feat: Support cancellation for Feed's endpoints
* feat: Support cancellation for Content's endpoints
* feat: Support cancellation for Tags' endpoints